### PR TITLE
relax peer dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "peerDependencies": {
-    "fuse-box": "^3.4.0"
+    "fuse-box": ">=3.4.0"
   },
   "devDependencies": {
     "@types/jest": "^22.1.3",


### PR DESCRIPTION
@tobiastimm I'm getting this on more recent versions of fusebox:

```fuse-box-ng-template-plugin@1.0.3 requires a peer of fuse-box@^3.4.0 but none is installed. You must install peer dependencies yourself.```